### PR TITLE
Hide cursor while animations display

### DIFF
--- a/internal/breathing/session.go
+++ b/internal/breathing/session.go
@@ -5,6 +5,7 @@ package breathing
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"runtime"
 	"strings"
 	"time"
@@ -58,6 +59,18 @@ func (s *Session) ParseArgs(args []string) {
 			s.SimpleMode = true
 		}
 	}
+}
+
+func (s Session) HideCursor() func() {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, sigint...)
+	fmt.Print("\033[?25l")
+	go func() {
+		s := <-sig
+		fmt.Println("\033[?25h")
+		sigexit(s)
+	}()
+	return func() { fmt.Println("\033[?25h") }
 }
 
 // Start begins the breathing session with visualization

--- a/internal/breathing/signal_other.go
+++ b/internal/breathing/signal_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package breathing
+
+import (
+	"os"
+)
+
+var sigint = []os.Signal{os.Interrupt, os.Kill}
+
+func sigexit(s os.Signal) {
+	os.Exit(1)
+}

--- a/internal/breathing/signal_unix.go
+++ b/internal/breathing/signal_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package breathing
+
+import (
+	"os"
+	"syscall"
+)
+
+var sigint = []os.Signal{syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT}
+
+func sigexit(s os.Signal) {
+	os.Exit(128 + int(s.(syscall.Signal)))
+}

--- a/internal/cli/handlers.go
+++ b/internal/cli/handlers.go
@@ -51,6 +51,7 @@ func HandleNow(args []string) {
 	session := breathing.NewSession()
 	session.ParseArgs(args)
 
+	defer session.HideCursor()()
 	session.Start()
 
 	if session.ShouldShowQuote() {


### PR DESCRIPTION
Looks rather nicer, IMHO. This should work on pretty much all modern terminals (ref: https://www.arp242.net/safeterm.html#misc).

Just defer isn't enough to restore the state in case someone pressed ^C or ran "pkill zenta" or the like, so we need to install a signal handler. Just os.Interupt isn't enough for that either and syscall won't work on e.g. Windows, so we need to use build tags to deal with that.