### PR TITLE
Add whitespace to clear characters on exhale

### DIFF
--- a/internal/breathing/session.go
+++ b/internal/breathing/session.go
@@ -134,7 +134,7 @@ func (s *Session) drawSimpleBreathingSession() {
 
 		// Exhale phase
 		s.drawSimplePhase("🌸", "Release slowly...", s.ExhaleDur, []string{
-			"●●●●", "●●●○", "●●○○", "●○○○", "○○○○", "○○", "·",
+			"●●●●", "●●●○", "●●○○", "●○○○", "○○○○", "○○  ", "·   ",
 		})
 
 		// Rest phase


### PR DESCRIPTION
When running `now` with the simple option the Exhale step only writes `.` without cleaning the previous characters
```
$ zenta now -q -s --simple

       Let's breathe 🌸

       🌬️ Breathe in gently...
          ●●●●

       ✨ Hold softly...
          ●●●●

       🌸 Release slowly...
          ·○○○

       🕯️ Rest in emptiness...
          ·

       🙏 Complete


       Carry this calm with you throughout your day 🙏
```

This PR adds whitespaces on the Exhale to clear any previous written characters
```
$ zenta now -q -s --simple

       Let's breathe 🌸

       🌬️ Breathe in gently...
          ●●●●

       ✨ Hold softly...
          ●●●●

       🌸 Release slowly...
          ·

       🕯️ Rest in emptiness...
          ·

       🙏 Complete


       Carry this calm with you throughout your day 🙏
```